### PR TITLE
Add support for IADs:Put and IADs:SetInfo

### DIFF
--- a/api/iads_stub.go
+++ b/api/iads_stub.go
@@ -54,9 +54,15 @@ func (v *IADs) GetEx(name string) (prop *ole.VARIANT, err error) {
 	return nil, ole.NewError(ole.E_NOTIMPL)
 }
 
-// Put sets the values of an attribute in the ADSI attribute cache. The value
-// must be commited with SetInfo to be made persistent.
-func (v *IADs) Put(name string, val interface{}) error {
+// PutInt sets the values of an int attribute in the ADSI attribute
+// cache. The value must be commited with SetInfo to be made persistent.
+func (v *IADs) PutInt(name string, val int) error {
+	return  ole.NewError(ole.E_NOTIMPL)
+}
+
+// PutString sets the values of a string attribute in the ADSI attribute
+// cache. The value must be commited with SetInfo to be made persistent.
+func (v *IADs) PutString(name string, val string) error {
 	return  ole.NewError(ole.E_NOTIMPL)
 }
 

--- a/api/iads_stub.go
+++ b/api/iads_stub.go
@@ -53,3 +53,14 @@ func (v *IADs) Get(name string) (prop *ole.VARIANT, err error) {
 func (v *IADs) GetEx(name string) (prop *ole.VARIANT, err error) {
 	return nil, ole.NewError(ole.E_NOTIMPL)
 }
+
+// Put sets the values of an attribute in the ADSI attribute cache. The value
+// must be commited with SetInfo to be made persistent.
+func (v *IADs) Put(name string, val interface{}) error {
+	return  ole.NewError(ole.E_NOTIMPL)
+}
+
+// SetInfo saves the cached property values of the ADSI object to the underlying directory store.
+func (v *IADs) SetInfo() error {
+	return  ole.NewError(ole.E_NOTIMPL)
+}

--- a/object.go
+++ b/object.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/go-adsi/adsi/api"
+	"github.com/go-adsi/adsi/comiid"
 	ole "github.com/go-ole/go-ole"
 	"github.com/google/uuid"
 	"github.com/scjalliance/comshim"
 	"github.com/scjalliance/comutil"
-	"github.com/go-adsi/adsi/api"
-	"github.com/go-adsi/adsi/comiid"
 )
 
 // ADSI Objects of LDAP:  https://msdn.microsoft.com/library/aa772208
@@ -497,6 +497,27 @@ func (o *object) AttrGUID(name string) (attr uuid.UUID, err error) {
 		attr = array[0]
 	}
 	return
+}
+
+// Put sets the values of an attribute in the ADSI attribute cache.
+func (o *object) Put(name string, val interface{}) error {
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.closed() {
+		return ErrClosed
+	}
+	return o.iface.Put(name, val)
+}
+
+// SetInfo saves the cached property values of the ADSI object to the underlying
+// directory store.
+func (o *object) SetInfo() error {
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.closed() {
+		return ErrClosed
+	}
+	return o.iface.SetInfo()
 }
 
 // ToContainer attempts to acquire a container interface for the object.


### PR DESCRIPTION
Adds support for modifying object properties via ADSI.

Ref:
https://docs.microsoft.com/en-us/windows/win32/api/iads/nf-iads-iads-put
https://docs.microsoft.com/en-us/windows/win32/api/iads/nf-iads-iads-setinfo