### PR TITLE
Add support for group.Add and group.Remove.

### DIFF
--- a/api/iadsgroup_stub.go
+++ b/api/iadsgroup_stub.go
@@ -4,6 +4,11 @@ package api
 
 import "github.com/go-ole/go-ole"
 
+// Add adds an ADSI object to an existing group.
+func (v *IADsGroup) Add(member string) (err error) {
+	return ole.NewError(ole.E_NOTIMPL)
+}
+
 // Description retrieves the description of the group.
 func (v *IADsGroup) Description() (desc string, err error) {
 	return "", ole.NewError(ole.E_NOTIMPL)
@@ -13,4 +18,10 @@ func (v *IADsGroup) Description() (desc string, err error) {
 // membership of the group.
 func (v *IADsGroup) Members() (members *IADsMembers, err error) {
 	return nil, ole.NewError(ole.E_NOTIMPL)
+}
+
+// Remove removes the specified user object from this group. The operation
+// does not remove the group object itself even when there is no member remaining in the group.
+func (v *IADsGroup) Remove(member string) (err error) {
+	return ole.NewError(ole.E_NOTIMPL)
 }

--- a/api/iadsgroup_windows.go
+++ b/api/iadsgroup_windows.go
@@ -9,6 +9,25 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+// Add adds an ADSI object to an existing group.
+func (v *IADsGroup) Add(member string) (err error) {
+	m := ole.SysAllocStringLen(member)
+	if m == nil {
+		return ole.NewError(ole.E_OUTOFMEMORY)
+	}
+	defer ole.SysFreeString(m)
+	hr, _, _ := syscall.Syscall(
+		uintptr(v.VTable().Add),
+		2,
+		uintptr(unsafe.Pointer(v)),
+		uintptr(unsafe.Pointer(m)),
+		0)
+	if hr != 0 {
+		return convertHresultToError(hr)
+	}
+	return
+}
+
 // Description retrieves the description of the group.
 func (v *IADsGroup) Description() (desc string, err error) {
 	var bstr *int16
@@ -40,6 +59,26 @@ func (v *IADsGroup) Members() (members *IADsMembers, err error) {
 		0)
 	if hr != 0 {
 		return nil, convertHresultToError(hr)
+	}
+	return
+}
+
+// Remove removes the specified user object from this group. The operation
+// does not remove the group object itself even when there is no member remaining in the group.
+func (v *IADsGroup) Remove(member string) (err error) {
+	m := ole.SysAllocStringLen(member)
+	if m == nil {
+		return ole.NewError(ole.E_OUTOFMEMORY)
+	}
+	defer ole.SysFreeString(m)
+	hr, _, _ := syscall.Syscall(
+		uintptr(v.VTable().Remove),
+		2,
+		uintptr(unsafe.Pointer(v)),
+		uintptr(unsafe.Pointer(m)),
+		0)
+	if hr != 0 {
+		return convertHresultToError(hr)
 	}
 	return
 }

--- a/group.go
+++ b/group.go
@@ -22,6 +22,16 @@ func (g *Group) closed() bool {
 	return (g.iface == nil)
 }
 
+// Add adds an ADSI object to an existing group.
+func (g *Group) Add(item string) (err error) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	if g.closed() {
+		return ErrClosed
+	}
+	return g.iface.Add(item)
+}
+
 // Close will release resources consumed by the group. It should be
 // called when the group is no longer needed.
 func (g *Group) Close() {
@@ -61,4 +71,15 @@ func (g *Group) Members() (m *Members, err error) {
 	}
 	m = NewMembers(imembers)
 	return
+}
+
+// Remove removes the specified user object from this group. The operation
+// does not remove the group object itself even when there is no member remaining in the group.
+func (g *Group) Remove(item string) error {
+	g.m.Lock()
+	defer g.m.Unlock()
+	if g.closed() {
+		return ErrClosed
+	}
+	return g.iface.Remove(item)
 }


### PR DESCRIPTION
Enables IADsGroup::Add and IADsGroup::Remove.

Ref: 
https://docs.microsoft.com/en-us/windows/win32/api/iads/nf-iads-iadsgroup-add
https://docs.microsoft.com/en-us/windows/win32/api/iads/nf-iads-iadsgroup-remove
