### PR TITLE
fix convert overflow

### DIFF
--- a/api/iadslargeinteger_windows.go
+++ b/api/iadslargeinteger_windows.go
@@ -46,5 +46,5 @@ func (v *IADsLargeInteger) Value() (value int64, err error) {
 	if err != nil {
 		return
 	}
-	return (int64(upper) << 32) | int64(lower), nil
+	return (int64(uint32(upper)) << 32) | int64(uint32(lower)), nil
 }


### PR DESCRIPTION
The returned int32 must be converted to uint32 before casting them to int64 for combination, if the int32 is interpreted as negative signed integer the conversion will be totally wrong, it was probably a design mistake from Microsoft to return IADsLargeInteger High and Low Part as LONG and not ULONG.
You can see here: https://learn.microsoft.com/en-us/windows/win32/api/iads/nn-iads-iadslargeinteger in the example that shows how to convert an IADsLargeInteger to a 64-bit integer the cast to ULONG before convert